### PR TITLE
Move event returns game pieces

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "octadground",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "lioctad.org octad ui",
   "type": "commonjs",
   "main": "octadground.js",

--- a/src/board.ts
+++ b/src/board.ts
@@ -103,7 +103,7 @@ export function baseMove(state: HeadlessState, orig: og.Key, dest: og.Key): og.P
   if (orig === dest || !origPiece) return false;
   const captured = destPiece && destPiece.color !== origPiece.color ? destPiece : undefined;
   if (dest === state.selected) unselect(state);
-  callUserFunction(state.events.move, orig, dest, captured);
+  callUserFunction(state.events.move, orig, dest, state.pieces, captured);
   if (!tryAutoCastle(state, orig, dest)) {
     state.pieces.set(dest, origPiece);
     state.pieces.delete(orig);

--- a/src/config.ts
+++ b/src/config.ts
@@ -69,7 +69,7 @@ export interface Config {
     change?: () => void; // called after the situation changes on the board
     // called after a piece has been moved.
     // capturedPiece is undefined or like {color: 'white'; 'role': 'queen'}
-    move?: (orig: og.Key, dest: og.Key, capturedPiece?: og.Piece) => void;
+    move?: (orig: og.Key, dest: og.Key, pieces: og.Pieces, capturedPiece?: og.Piece) => void;
     dropNewPiece?: (piece: og.Piece, key: og.Key) => void;
     select?: (key: og.Key) => void; // called when a square is selected
     insert?: (elements: og.Elements) => void; // when the board DOM has been (re)inserted

--- a/src/state.ts
+++ b/src/state.ts
@@ -88,7 +88,7 @@ export interface HeadlessState {
     change?: () => void; // called after the situation changes on the board
     // called after a piece has been moved.
     // capturedPiece is undefined or like {color: 'white'; 'role': 'queen'}
-    move?: (orig: og.Key, dest: og.Key, capturedPiece?: og.Piece) => void;
+    move?: (orig: og.Key, dest: og.Key, pieces: og.Pieces, capturedPiece?: og.Piece) => void;
     dropNewPiece?: (piece: og.Piece, key: og.Key) => void;
     select?: (key: og.Key) => void; // called when a square is selected
     insert?: (elements: og.Elements) => void; // when the board DOM has been (re)inserted


### PR DESCRIPTION
## Changes

- Updates the `move` event to return all game pieces.
- Bumps version from `1.0.2` to `1.03`.